### PR TITLE
Create a build.log for each generated site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ automatically from [GitHub](https://github.com/) repositories in a similar
 fashion to [GitHub pages](https://pages.github.com/).
 
 Pages will appear on `https://pages.18f.gov/$REPO-NAME`, where `$REPO-NAME` is
-the name of the site repository on https://github.com/18F/.
+the name of the site repository on https://github.com/18F/. The status of the
+most recent build attempt will be visible at
+`https://pages.18f.gov/$REPO-NAME/build.log`.
 
 ### Adding a new site
 


### PR DESCRIPTION
Per #4. @adelevie if you push on me to add tests and whatnot, I will not fight you. :-) Sample output from `https://pages.18f.gov/guides-template/build.log`:

```
guides-template: starting build at commit 80f273707625a99eab4c35dfa4bf2d54389e5ab4
description: Include Google Analytics code and instructions
timestamp: 2015-04-28T03:36:51-04:00
committer: michael.bland@gsa.gov
syncing repo: guides-template
guides-template: build successful
```