### PR TITLE
Fix logging error; log more information

### DIFF
--- a/hookshot.js
+++ b/hookshot.js
@@ -122,7 +122,7 @@ SiteBuilder.prototype.clone_repo = function() {
     if (code != 0) {
       that.done("Error: failed to clone " + that.repo_name +
         " with exit code " + code + " from command: "
-        + path + " " + args.join(" "));
+        + GIT + " " + clone_args.join(" "));
     } else {
       that.check_for_bundler();
     }
@@ -162,10 +162,13 @@ function launch_builder(info, dest_dir, repo_dir) {
   var commit = info.head_commit;
   var build_log = site_path + '.log';
   var logger = new BuildLogger(build_log);
-  logger.log(repo_name + ':', 'starting build at commit', commit.id);
+  logger.log(info.repository.full_name + ':',
+    'starting build at commit', commit.id);
   logger.log('description:', commit.message);
   logger.log('timestamp:', commit.timestamp);
   logger.log('committer:', commit.committer.email);
+  logger.log('pusher:', info.pusher.name, info.pusher.email);
+  logger.log('sender:', info.sender.login);
 
   var builder = new SiteBuilder(repo_dir, repo_name, dest_dir, site_path,
     branch, logger, function(err) {


### PR DESCRIPTION
Seems like we had a funny guy poking about yesterday:

```
terrible-things: starting build at commit 251c6e89838cc06a83c72e0f3fb7e72ff6e1876e
description: Create gh-pages branch via GitHub
timestamp: 2015-06-04T17:19:21-04:00
committer: dhcole+eval@gmail.com
cloning terrible-things into /home/ubuntu/pages-repos/terrible-things
Cloning into 'terrible-things'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

/home/ubuntu/pages/hookshot.js:125
        + path + " " + args.join(" "));
                       ^
ReferenceError: args is not defined
    at ChildProcess.<anonymous> (/home/ubuntu/pages/hookshot.js:125:24)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:766:16)
    at Process.ChildProcess._handle.onexit (child_process.js:833:5)
error: Forever detected script exited with code: 8
error: Script restart attempt #2
18F pages: listening on port 5000
terrible-things: starting build at commit 5e271dfd8f8743f637c8af2f1fb736cf2cdb5534
description: Create README.md
timestamp: 2015-06-04T17:22:55-04:00
committer: evaldoer@users.noreply.github.com
cloning terrible-things into /home/ubuntu/pages-repos/terrible-things
Thu, 04 Jun 2015 21:22:56 GMT express deprecated res.send(status, body): Use res.status(status).send(body) instead at node_modules/hookshot/lib/index.js:33:9
Cloning into 'terrible-things'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

/home/ubuntu/pages/hookshot.js:125
        + path + " " + args.join(" "));
                       ^
ReferenceError: args is not defined
    at ChildProcess.<anonymous> (/home/ubuntu/pages/hookshot.js:125:24)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:766:16)
    at Process.ChildProcess._handle.onexit (child_process.js:833:5)
error: Forever detected script exited with code: 8
```

The script is hardcoded to only accept 18F repos, so no harm was ultimately done. However, the error message-building code is obviously broken, and without the full name of the repo, etc., I can't figure out who this `evaldoer@users.noreply.github.com` is.

So this change accomplishes two things:
- It fixes the `git clone` error message.
- It logs the full repo name and additional info on who pushed the commit/sent the webhook.

Resending a valid, successful webhook results in:

```
18F/pages: starting build at commit 033d2faa801732b6d7a2e8151fec4d430e0a9dfd
description: Merge pull request #12 from 18F/support-staging

Support staging
timestamp: 2015-06-04T16:00:28-04:00
committer: aidan.feldman@gmail.com
pusher: afeld aidan.feldman@gmail.com
sender: afeld
syncing repo: pages
```

cc: @afeld @dhcole @gboone 
