### PR TITLE
Pass through bodyParser.json() middleware options

### DIFF
--- a/hookshot.js
+++ b/hookshot.js
@@ -192,17 +192,21 @@ function launch_builder(info, dest_dir, repo_dir) {
   builder.build();
 }
 
+// Passed through to bodyParser.json().
+// See https://www.npmjs.com/package/bytes for `limit:` syntax.
+var json_options = { limit: 1 << 20 };
+
 var webhook = hookshot('refs/heads/18f-pages', function(info) {
   launch_builder(info,
     path.join(home, "pages-generated"),
     path.join(home, "pages-repos"));
-});
+}, json_options);
 
 webhook.on('refs/heads/18f-pages-staging', function(info) {
   launch_builder(info,
     path.join(home, "pages-staging"),
     path.join(home, "pages-repos-staging"));
-});
+}, json_options);
 
 webhook.listen(port);
 

--- a/hookshot.js
+++ b/hookshot.js
@@ -193,7 +193,7 @@ function launch_builder(info, dest_dir, repo_dir) {
 }
 
 // Passed through to bodyParser.json().
-// See https://www.npmjs.com/package/bytes for `limit:` syntax.
+// https://www.npmjs.com/package/body-parser#limit
 var json_options = { limit: 1 << 20 };
 
 var webhook = hookshot('refs/heads/18f-pages', function(info) {


### PR DESCRIPTION
As noted in #14, the default 100KB payload limit was exceeded by a webhook fired for 18F/govt-wide-patternlibrary#54. Combined with 5d2ee1ec4899e8f4ff0e0f54bb16ac745df6d144 from 18F/hookshot (see coreh/hookshot#12), this change will allow us to pass options through to the bodyParser.json() middleware to increase the limit.

I've currently installed 18F/hookshot on our server using:

``` shell
$ npm install git+ssh://git@github.com/18F/hookshot.git#json-options
```

I've also updated the running instance of this server to use this version, and verified that it addresses our problem, evidenced by the logs and the successful first deployment of https://pages.18f.gov/govt-wide-patternlibrary/.

cc: @juliaelman
