### PR TITLE
Fix property name of incoming GitHub JSON payload

### DIFF
--- a/site-builder.js
+++ b/site-builder.js
@@ -139,7 +139,7 @@ SiteBuilder.prototype.jekyllBuild = function() {
 };
 
 exports.launchBuilder = function (info, builderOpts) {
-  var commit = info.headCommit;
+  var commit = info.head_commit;
   var buildLog = builderOpts.sitePath + '.log';
   var logger = new buildLogger.BuildLogger(buildLog);
   logger.log(info.repository.fullName + ':',


### PR DESCRIPTION
To satisfy jshint, I'd inadvertenly renamed the `head_commit` property of the
incoming webhook payload to `headCommit`.

Going to merge this myself, as this is currently preventing updates to https://pages.18f.gov/.

cc: @msecret @arowla
