### PR TITLE
Update SiteBuilder to use Promises

### DIFF
--- a/_test/site_builder_test.js
+++ b/_test/site_builder_test.js
@@ -80,7 +80,7 @@ describe('SiteBuilder', function() {
     logMock.expects('log').withExactArgs(
         'cloning', 'repo_name', 'into', 'new_dir');
     builder = makeBuilder('new_dir', check(done, function(err) {
-      expect(err).to.be.null;
+      expect(err).to.be.undefined;
       expect(spawnCalls()).to.eql([
         'git clone git@github.com:18F/repo_name.git --branch 18f-pages',
         'jekyll build --trace --destination dest_dir/repo_name',
@@ -110,7 +110,7 @@ describe('SiteBuilder', function() {
     logMock.expects('log').withExactArgs('syncing repo:', 'repo_name');
     createRepoDir(function() {
       builder = makeBuilder(testRepoDir, check(done, function(err) {
-        expect(err).to.be.null;
+        expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql([
           'git pull',
           'jekyll build --trace --destination dest_dir/repo_name',
@@ -126,7 +126,7 @@ describe('SiteBuilder', function() {
     logMock.expects('log').withExactArgs('syncing repo:', 'repo_name');
     createRepoWithGemfile(function() {
       builder = makeBuilder(testRepoDir, check(done, function(err) {
-        expect(err).to.be.null;
+        expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql([
           'git pull',
           'bundle install',

--- a/site-builder.js
+++ b/site-builder.js
@@ -78,11 +78,14 @@ function SiteBuilder(opts, buildLogger, doneCallback) {
 }
 
 SiteBuilder.prototype.build = function() {
-  if (fs.existsSync(this.sitePath)) {
-    this.syncRepo();
-  } else {
-    this.cloneRepo();
-  }
+  var that = this;
+  fs.exists(this.sitePath, function(exists) {
+    if (exists) {
+      that.syncRepo();
+    } else {
+      that.cloneRepo();
+    }
+  });
 };
 
 SiteBuilder.prototype.syncRepo = function() {
@@ -113,12 +116,15 @@ SiteBuilder.prototype.cloneRepo = function() {
 };
 
 SiteBuilder.prototype.checkForBundler = function() {
-  this.usesBundler = fs.existsSync(path.join(this.sitePath, 'Gemfile'));
-  if (this.usesBundler) {
-    this.updateBundle();
-  } else {
-    this.jekyllBuild();
-  }
+  var that = this;
+  fs.exists(path.join(this.sitePath, 'Gemfile'), function(exists) {
+    that.usesBundler = exists;
+    if (that.usesBundler) {
+      that.updateBundle();
+    } else {
+      that.jekyllBuild();
+    }
+  });
 };
 
 SiteBuilder.prototype.updateBundle = function() {

--- a/site-builder.js
+++ b/site-builder.js
@@ -63,16 +63,18 @@ function SiteBuilder(opts, buildLogger, doneCallback) {
 
   var that = this;
   this.spawn = function(path, args, next) {
-    var opts = {cwd: that.sitePath, stdio: 'inherit'};
+    return new Promise(function() {
+      var opts = {cwd: that.sitePath, stdio: 'inherit'};
 
-    childProcess.spawn(path, args, opts).on('close', function(code) {
-      if (code !== 0) {
-        that.done('Error: rebuild failed for ' + that.repoName +
-          ' with exit code ' + code + ' from command: ' +
-          path + ' ' + args.join(' '));
-      } else {
-        next();
-      }
+      childProcess.spawn(path, args, opts).on('close', function(code) {
+        if (code !== 0) {
+          that.done('Error: rebuild failed for ' + that.repoName +
+            ' with exit code ' + code + ' from command: ' +
+            path + ' ' + args.join(' '));
+        } else {
+          next();
+        }
+      });
     });
   };
 }


### PR DESCRIPTION
Now SiteBuilder.build() contains the entire algorithm! No more scanning from state to state! And check it out: the only changes necessary in the test were to switch some `null` expectations to `undefined`!

This will certainly make it easier to inject additional steps for future features.

Hat tip to @vzvenyach for putting the Promises bug in my ear when I first showed him the Pages server.

cc: @arowla @msecret 
