### PR TITLE
Ensure the baseurl resolves to pages.18f.gov/

### DIFF
--- a/_config_18f_pages.yml
+++ b/_config_18f_pages.yml
@@ -1,0 +1,2 @@
+baseurl:
+asset_root: /guides-template


### PR DESCRIPTION
I just checked, and the only 18F Pages repo whose `baseurl:` needs to be explicitly set before rolling out #24 is this one. :-)

cc: @arowla @afeld @konklone 
