### PR TITLE
Run git stash when syncing a repo

### DIFF
--- a/_test/site_builder_test.js
+++ b/_test/site_builder_test.js
@@ -180,6 +180,7 @@ describe('SiteBuilder', function() {
         expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql([
           'git pull',
+          'git stash',
           'jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
         ]);
@@ -201,6 +202,7 @@ describe('SiteBuilder', function() {
         expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql([
           'git pull',
+          'git stash',
           'bundle install',
           'bundle exec jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
@@ -213,6 +215,7 @@ describe('SiteBuilder', function() {
 
   it ('should fail if bundle install fails', function(done) {
     mySpawn.sequence.add(mySpawn.simple(0));
+    mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(1));
     logMock.expects('log').withExactArgs('syncing repo:', 'repo_name');
     createRepoWithFile(gemfile, function() {
@@ -220,7 +223,8 @@ describe('SiteBuilder', function() {
         var bundleInstallCommand = 'bundle install';
         expect(err).to.equal('Error: rebuild failed for repo_name with ' +
           'exit code 1 from command: ' + bundleInstallCommand);
-        expect(spawnCalls()).to.eql(['git pull', bundleInstallCommand]);
+        expect(spawnCalls()).to.eql([
+          'git pull', 'git stash', bundleInstallCommand]);
         logMock.verify();
       }));
       builder.build();
@@ -228,6 +232,7 @@ describe('SiteBuilder', function() {
   });
 
   it ('should fail if jekyll build fails', function(done) {
+    mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(1));
@@ -244,7 +249,7 @@ describe('SiteBuilder', function() {
         expect(err).to.equal('Error: rebuild failed for repo_name with ' +
           'exit code 1 from command: ' + jekyllBuildCommand);
         expect(spawnCalls()).to.eql([
-          'git pull', 'bundle install', jekyllBuildCommand]);
+          'git pull', 'git stash', 'bundle install', jekyllBuildCommand]);
         logMock.verify();
       }));
       builder.build();
@@ -261,6 +266,7 @@ describe('SiteBuilder', function() {
         expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql([
           'git pull',
+          'git stash',
           'jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
         ]);

--- a/site-builder.js
+++ b/site-builder.js
@@ -116,7 +116,9 @@ SiteBuilder.prototype.build = function() {
 
 SiteBuilder.prototype.syncRepo = function() {
   this.logger.log('syncing repo:', this.repoName);
-  return this.spawn(this.git, ['pull']);
+  var that = this;
+  return this.spawn(this.git, ['pull'])
+    .then(function() { that.spawn(that.git, ['stash']); });
 };
 
 SiteBuilder.prototype.cloneRepo = function() {


### PR DESCRIPTION
There've been failures where running `bundle install` causes updates to Gemfile.lock, causing merge conflicts during  `git pull` when new requests come in. This stashes any local changes, rather than running `git reset --hard HEAD`, so we can later find and diagnose future such events where the local
working copy has been updated.

I noticed @gboone used `stash` instead of `reset` in the [18f.gsa.gov `./go` script](https://github.com/18F/18f.gsa.gov/blob/staging/go), hence my reasoning.

cc: @arowla @afeld @msecret
