### PR TITLE
Extract all config into pages-config.json

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -7,7 +7,7 @@ fabric.api.env.hosts = ['18f-pages']
 CMD = "pages/hookshot.js"
 
 def start():
-  fabric.api.run("forever start -l pages.log -a %s" % CMD)
+  fabric.api.run("forever start -l $HOME/pages.log -a %s" % CMD)
 
 def stop():
   fabric.api.run("forever stop %s" % CMD)

--- a/fabfile.py
+++ b/fabfile.py
@@ -2,26 +2,12 @@
 
 import fabric.api
 
-# Specifies the hook to manage. Defaults to internal; override with:
-#   fab [command] --set instance=public"
-INSTANCE = fabric.api.env.get('instance', 'internal')
-
-SETTINGS = {
-  'internal': {
-    'host': '18f-pages', 'port': 5000, 'home': '/home/ubuntu',
-    'rbenv': '/usr/local/rbenv'
-  },
-}[INSTANCE]
-
 fabric.api.env.use_ssh_config = True
-fabric.api.env.hosts = [SETTINGS['host']]
-
-LOG = "%s/pages.log" % SETTINGS['home']
-CMD = "pages/hookshot.js --port %i --home %s --rbenv %s" % (
-  SETTINGS['port'], SETTINGS['home'], SETTINGS['rbenv'])
+fabric.api.env.hosts = ['18f-pages']
+CMD = "pages/hookshot.js"
 
 def start():
-  fabric.api.run("forever start -l %s -a %s" % (LOG, CMD))
+  fabric.api.run("forever start -l pages.log -a %s" % CMD)
 
 def stop():
   fabric.api.run("forever stop %s" % CMD)

--- a/pages-config.json
+++ b/pages-config.json
@@ -1,0 +1,20 @@
+{
+  "port":         5000,
+  "home":         "/home/ubuntu",
+  "git":          "/usr/bin/git",
+  "bundler":      "/usr/local/rbenv/shims/bundle",
+  "jekyll":       "/usr/local/rbenv/shims/jekyll",
+  "payloadLimit": 1048576,
+  "builders": [
+    {
+      "branch":           "18f-pages",
+      "repositoryDir":    "pages-repos",
+      "generatedSiteDir": "pages-generated"
+    },
+    {
+      "branch":           "18f-pages-staging",
+      "repositoryDir":    "pages-repos-staging",
+      "generatedSiteDir": "pages-staging"
+    }
+  ]
+}


### PR DESCRIPTION
First step towards genericizing the server for potential use by other organizations. I'm thinking I'll eventually specify the GitHub org in the `pages-config.json` object, and then make an npm out of the whole thing.

Already experimented with this branch successfully in production.

cc: @arowla @gbinal @konklone @msecret @shawnbot 
