### PR TITLE
FileLockedOperation to prevent overlapping updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ following settings:
 * **git**:  path to `git` on the host machine
 * **bundler**: path to `bundle` on the host machine
 * **jekyll**:  path to `jekyll` on the host machine
+* **rsync**: path to `rsync` on the host machine
+* **rsyncOpts**: options to pass to `rsync` that control Jekyll-less builds
 * **payloadLimit**: maximum allowable size (in bytes) for incoming webhooks
 * **githubOrg**: GitHub organization to which all published repositories
   belong

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
+    "file-locked-operation": "0.0.0",
     "gulp": "^3.9.0",
     "gulp-jshint": "^1.11.2",
     "gulp-mocha": "^2.1.3",

--- a/pages.js
+++ b/pages.js
@@ -29,10 +29,10 @@ function SiteBuilderOptions(info, repoDir, destDir) {
 
 var webhook = hookshot();
 
-function makeBuilderListener(builder) {
-  webhook.on('refs/heads/' + builder.branch, function(info) {
+function makeBuilderListener(builderConfig) {
+  webhook.on('refs/heads/' + builderConfig.branch, function(info) {
     siteBuilder.launchBuilder(info, new SiteBuilderOptions(
-      info, builder.repositoryDir, builder.generatedSiteDir));
+      info, builderConfig.repositoryDir, builderConfig.generatedSiteDir));
   }, jsonOptions);
 }
 

--- a/site-builder.js
+++ b/site-builder.js
@@ -115,10 +115,10 @@ SiteBuilder.prototype.build = function() {
   var that = this;
   this.updateLock.doLockedOperation(function(done) {
     fs.exists(that.sitePath, function(exists) {
-      (exists === true ? that.syncRepo() : that.cloneRepo())
+      (exists ? that.syncRepo() : that.cloneRepo())
         .then(function() { return that.checkForFile('_config.yml'); })
         .then(function(useJekyll) {
-          return (useJekyll === true ? that._buildJekyll() : that._rsync());
+          return (useJekyll ? that._buildJekyll() : that._rsync());
         })
         .then(done, done);
     });

--- a/site-builder.js
+++ b/site-builder.js
@@ -220,7 +220,7 @@ exports.launchBuilder = function (info, builderOpts) {
   var commit = info.head_commit;  // jshint ignore:line
   var buildLog = builderOpts.sitePath + '.log';
   var logger = new buildLogger.BuildLogger(buildLog);
-  logger.log(info.repository.fullName + ':',
+  logger.log(info.repository.full_name + ':',   // jshint ignore:line
     'starting build at commit', commit.id);
   logger.log('description:', commit.message);
   logger.log('timestamp:', commit.timestamp);

--- a/site-builder.js
+++ b/site-builder.js
@@ -6,6 +6,7 @@
 var fs = require('fs');
 var path = require('path');
 var buildLogger = require('./build-logger');
+var fileLockedOperation = require('file-locked-operation');
 var childProcess = require('child_process');
 var config = require('./pages-config.json');
 
@@ -58,15 +59,17 @@ function Options(info, repoDir, destDir, git, bundler, jekyll, rsync,
 //
 // opts: Options object
 // buildLogger: BuildLogger instance
+// updateLock: FileLockedOperation instance
 // doneCallback: callback triggered when the algorithm exits; takes a single
 //   `err` argument which will be nil on success, and an error string on
 //   failure
-function SiteBuilder(opts, buildLogger, doneCallback) {
+function SiteBuilder(opts, buildLogger, updateLock, doneCallback) {
   this.repoDir = opts.repoDir;
   this.repoName = opts.repoName;
   this.sitePath = opts.sitePath;
   this.branch = opts.branch;
   this.logger = buildLogger;
+  this.updateLock = updateLock;
   this.buildDestination = path.join(opts.destDir, opts.repoName);
   this.git = opts.git;
   this.bundler = opts.bundler;
@@ -110,14 +113,16 @@ function SiteBuilder(opts, buildLogger, doneCallback) {
 
 SiteBuilder.prototype.build = function() {
   var that = this;
-  fs.exists(this.sitePath, function(exists) {
-    (exists === true ? that.syncRepo() : that.cloneRepo())
-      .then(function() { return that.checkForFile('_config.yml'); })
-      .then(function(useJekyll) {
-        return (useJekyll === true ? that._buildJekyll() : that._rsync());
-      })
-      .then(that.done, that.done);
-  });
+  this.updateLock.doLockedOperation(function(done) {
+    fs.exists(that.sitePath, function(exists) {
+      (exists === true ? that.syncRepo() : that.cloneRepo())
+        .then(function() { return that.checkForFile('_config.yml'); })
+        .then(function(useJekyll) {
+          return (useJekyll === true ? that._buildJekyll() : that._rsync());
+        })
+        .then(done, done);
+    });
+  }, this.done);
 };
 
 SiteBuilder.prototype._rsync = function() {
@@ -223,7 +228,10 @@ exports.launchBuilder = function (info, builderOpts) {
   logger.log('pusher:', info.pusher.name, info.pusher.email);
   logger.log('sender:', info.sender.login);
 
-  var builder = new SiteBuilder(builderOpts, logger, function(err) {
+  var lockfilePath = path.join(builderOpts.destDir,
+    '.update-lock-' + builderOpts.repoName);
+  var updateLock = new fileLockedOperation.FileLockedOperation(lockfilePath);
+  var builder = new SiteBuilder(builderOpts, logger, updateLock, function(err) {
     if (err !== undefined) {
       logger.error(err);
       logger.error(builderOpts.repoName + ': build failed');


### PR DESCRIPTION
For each site, a lock file will prevent any incoming updates from interfering with one another. Updates across multiple sites will still happen in parallel.

This will also enable us to move to an org-wide webhook publishing model, eliminating the need for individual repos to set up webhooks, without having multiple webhooks firing during the transition cause  failures.

cc: @arowla (and mind peeking at 18F/team-api.18f.gov#108, too? ;-)
