### PR TITLE
Ensure 18F/hookshot is run; pass jsonOptions right

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -8,13 +8,13 @@ PAGES_DIR = "pages"
 CMD = "pages.js"
 
 def start():
-  with fabric.api.cd("pages"):
+  with fabric.api.cd(PAGES_DIR):
     fabric.api.run("forever start -l $HOME/pages.log -a %s" % CMD)
 
 def stop():
-  with fabric.api.cd("pages"):
+  with fabric.api.cd(PAGES_DIR):
     fabric.api.run("forever stop %s" % CMD)
 
 def restart():
-  with fabric.api.cd("pages"):
+  with fabric.api.cd(PAGES_DIR):
     fabric.api.run("forever restart %s" % CMD)

--- a/fabfile.py
+++ b/fabfile.py
@@ -4,13 +4,17 @@ import fabric.api
 
 fabric.api.env.use_ssh_config = True
 fabric.api.env.hosts = ['18f-pages']
-CMD = "pages/pages.js"
+PAGES_DIR = "pages"
+CMD = "pages.js"
 
 def start():
-  fabric.api.run("forever start -l $HOME/pages.log -a %s" % CMD)
+  with fabric.api.cd("pages"):
+    fabric.api.run("forever start -l $HOME/pages.log -a %s" % CMD)
 
 def stop():
-  fabric.api.run("forever stop %s" % CMD)
+  with fabric.api.cd("pages"):
+    fabric.api.run("forever stop %s" % CMD)
 
 def restart():
-  fabric.api.run("forever restart %s" % CMD)
+  with fabric.api.cd("pages"):
+    fabric.api.run("forever restart %s" % CMD)

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "mocha": "^2.2.5",
     "mock-spawn": "^0.2.6",
     "sinon": "^1.15.4"
+  },
+  "dependencies": {
+    "hookshot": "18f/hookshot#json-options"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
-    "file-locked-operation": "0.0.1",
     "gulp": "^3.9.0",
     "gulp-jshint": "^1.11.2",
     "gulp-mocha": "^2.1.3",
@@ -32,6 +31,7 @@
     "sinon": "^1.15.4"
   },
   "dependencies": {
+    "file-locked-operation": "0.0.1",
     "hookshot": "18f/hookshot#json-options"
   }
 }

--- a/pages.js
+++ b/pages.js
@@ -27,13 +27,13 @@ function SiteBuilderOptions(info, repoDir, destDir) {
     config.rsync, config.rsyncOpts);
 }
 
-var webhook = hookshot();
+var webhook = hookshot(null, null, jsonOptions);
 
 function makeBuilderListener(builderConfig) {
   webhook.on('refs/heads/' + builderConfig.branch, function(info) {
     siteBuilder.launchBuilder(info, new SiteBuilderOptions(
       info, builderConfig.repositoryDir, builderConfig.generatedSiteDir));
-  }, jsonOptions);
+  });
 }
 
 var numBuilders = config.builders.length;


### PR DESCRIPTION
`config.payloadLimit` wasn't getting passed to the `hookshot` constructor as it should have been, and therefore wasn't having any effect. This happened after the refactoring in #31 that generalized the creation of webhook listeners via `config.builders`, but no longer passed the `jsonOptions` object to the `hookshot` constructor.

On top of that, my changes in coreh/hookshot#12 still haven't been merged, and I hadn't made sure that my custom `18F/hookshot#json-options` branch was installed. (See also 18F/hookshot#14 and 18F/hookshot#15.)

Both issues are presently rectified in production via this change (by fetching this branch and running `npm install` in the host repo). I confirmed this by resending the webhook from 18F/web-design-standards that caused the server to fail earlier this evening, and observing a successful build in the log file.

cc: @arowla @afeld @maya @mollieru
