### PR TITLE
Fix logrotate issue with logs going to wrong file

### DIFF
--- a/_deploy/etc/logrotate.d/18f-pages-server
+++ b/_deploy/etc/logrotate.d/18f-pages-server
@@ -1,10 +1,11 @@
+# Note that copytruncate isn't a perfect solution, but it'll suffice for the
+# 18f-pages-server. For more information:
+# https://github.com/foreverjs/forever/issues/106#issuecomment-116933382
 /var/log/18f-pages-server/pages.log {
   rotate 12
   monthly
   compress
   missingok
   notifempty
-  postrotate
-    /usr/local/bin/forever restart /usr/local/bin/18f-pages
-  endscript
+  copytruncate
 }


### PR DESCRIPTION
Noticed that there was a new `/var/log/18f-pages-server/pages.log` file, but
that the logs were still going to an uncompressed
`/var/log/18f-pages-server/pages.log.1`. The old `postrotate` script wasn't
actually successfully restarting the server, and a manual restart also didn't
allow the new process to write to the new log file.

Found out about the `copytruncate` directive, which will work well enough for
18F Pages, though it's not completely ideal. For more information, this issue
has a very helpful comment with a ton of technical background:

https://github.com/foreverjs/forever/issues/106#issuecomment-116933382
