### PR TITLE
Script to list 18F repos with an 18-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+sudo: false
+script: ./go build
+rvm:
+- 2.2.3

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ exclude:
 - gulpfile.js
 - node_modules
 - package.json
+- vendor
 
 navigation:
 - text: Introduction

--- a/_scripts/all_pages.rb
+++ b/_scripts/all_pages.rb
@@ -1,0 +1,25 @@
+#! /usr/bin/env ruby
+
+require 'octokit'
+
+TOKEN_PATH = File.join(ENV['HOME'], '.github_token')
+
+unless File.exist? TOKEN_PATH
+  $stderr.puts "No GitHub token found at #{TOKEN_PATH}"
+  exit 1
+end
+
+access_token = File.read TOKEN_PATH
+Octokit.auto_paginate = true
+client = Octokit::Client.new access_token: access_token
+repos = client.org_repos '18F'
+
+pages_repos = []
+
+repos.each do |repo|
+  repo_name = repo.full_name
+  branches = client.branches(repo_name).map { |b| b.name }
+  pages_repos << repo_name if branches.include? '18f-pages'
+end
+
+pages_repos.sort.each { |repo| puts repo }

--- a/_scripts/all_pages.rb
+++ b/_scripts/all_pages.rb
@@ -12,12 +12,10 @@ end
 access_token = File.read TOKEN_PATH
 Octokit.auto_paginate = true
 client = Octokit::Client.new access_token: access_token
-repos = client.org_repos '18F'
+repos = client.org_repos('18F').collect { |repo| repo.full_name }
 
-pages_repos = repos.map do |repo|
-  repo_name = repo.full_name
-  branches = client.branches(repo_name).map { |b| b.name }
-  repo_name if branches.include? '18f-pages'
-end.compact.sort
+pages_repos = repos.select do |name|
+  client.branches(name).any? { |b| b.name == '18f-pages' }
+end.sort
 
 pages_repos.each { |repo| puts repo }

--- a/_scripts/all_pages.rb
+++ b/_scripts/all_pages.rb
@@ -14,12 +14,10 @@ Octokit.auto_paginate = true
 client = Octokit::Client.new access_token: access_token
 repos = client.org_repos '18F'
 
-pages_repos = []
-
-repos.each do |repo|
+pages_repos = repos.map do |repo|
   repo_name = repo.full_name
   branches = client.branches(repo_name).map { |b| b.name }
-  pages_repos << repo_name if branches.include? '18f-pages'
-end
+  repo_name if branches.include? '18f-pages'
+end.compact.sort
 
-pages_repos.sort.each { |repo| puts repo }
+pages_repos.each { |repo| puts repo }


### PR DESCRIPTION
First step towards implementing #51. Prints out all 18F repositories that contain an `18f-pages` branch. Right now, there's 61 of them.

Next step would be to check if there's a `_config_18f_pages.yml` file in the branch that overrides `baseurl:`. This should be very rare, but nonetheless is necessary for 100% correctness.

After that, we can generate a page in this repo that lists all of the 18F Pages sites.

(This could also become the basis for pruning old directories, via a cron job or something.)

cc: @arowla @ccostino @gbinal @melodykramer 
