### PR TITLE
Update link in comment to be canonical version

### DIFF
--- a/_deploy/etc/logrotate.d/18f-pages-server
+++ b/_deploy/etc/logrotate.d/18f-pages-server
@@ -1,6 +1,6 @@
 # Note that copytruncate isn't a perfect solution, but it'll suffice for the
 # 18f-pages-server. For more information:
-# https://github.com/foreverjs/forever/issues/106#issuecomment-116933382
+# http://mark.stosberg.com/blog/tech/possible-solutions-to-empty-files-after-log-rotation/
 /var/log/18f-pages-server/pages.log {
   rotate 12
   monthly


### PR DESCRIPTION
I wrote the comment that was linked to. I've now turned the comment into a blog post which I think makes a better reference link.
